### PR TITLE
Update Private-development-chain.md

### DIFF
--- a/Private-development-chain.md
+++ b/Private-development-chain.md
@@ -9,7 +9,7 @@ Run a development chain using:
 openethereum --config dev
 ```
 
-The created chain is initialized with an address that contains a lot of Ether - `0x00a329c0648769a73afac7f9381e08fb43dbea72`. Its private key is `0x4d5db4107d237df6a3d58ee5f70ae63d73d7658d4026f2eefd2f204c81682cb7`.
+The created chain is initialized with an address that contains a lot of Ether - `0x00a329c0648769a73afac7f9381e08fb43dbea72`. Its private key is `0x4d5db4107d237df6a3d58ee5f70ae63d73d7658d4026f2eefd2f204c81682cb7`. The account needs to be unlocked like any other account and the password is an empty string.
 
 ## Customizing the development chain
 


### PR DESCRIPTION
The private dev chain has a lot of large differences like auto-mining so it's easy to assume the default account is special too. The fact that it needs to be unlocked, as well as the account password, should be documented here.