### PR TITLE
remove the public address and private key

### DIFF
--- a/Private-development-chain.md
+++ b/Private-development-chain.md
@@ -9,8 +9,6 @@ Run a development chain using:
 openethereum --config dev
 ```
 
-The created chain is initialized with an address that contains a lot of Ether - `0x00a329c0648769a73afac7f9381e08fb43dbea72`. Its private key is `0x4d5db4107d237df6a3d58ee5f70ae63d73d7658d4026f2eefd2f204c81682cb7`.
-
 ## Customizing the development chain
 
 The default configuration should work fine in most cases. However, it can be customised. You can see the [chain specification for the dev network](https://github.com/openethereum/openethereum/blob/master/ethcore/res/instant_seal.json) in the source repository. You can make a copy locally, modify it and pass it to the `--chain` option. The last section of the file under `accounts` can be modified to add more accounts with lots of Ether. See the [Chain specification](Chain-specification) documentation for more details.


### PR DESCRIPTION
https://etherscan.io/address/0x00a329c0648769A73afAc7F9381E08FB43dBEA72

this address is listened by hack and if the developer forget to remove the account from metamask after development. once the mainnet money is
transfered to this address, the hack will transfer the money to somewhere else. 

There are so many eth the hacker have been success stolen, I lost 1 eth this morning:
https://etherscan.io/tx/0x7041400e301abc855832d20a5350783078df298e6fe14fb092ef1d9304f53ed9

faucet is a better solution than this!